### PR TITLE
fix: update devTools configuration to use import.meta.env.MODE

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,7 +9,7 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(movieApi.middleware),
   // Enable Redux DevTools in development
-  devTools: process.env.NODE_ENV !== "production",
+  devTools: import.meta.env.MODE !== "production",
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
Replaced process.env.NODE_ENV with import.meta.env.MODE to properly enable Redux DevTools in development mode when using Vite