### PR TITLE
feat: add custom font integration and update CSS variables

### DIFF
--- a/src/assets/fonts/fonts.css
+++ b/src/assets/fonts/fonts.css
@@ -1,0 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap");
+
+:root {
+  --font-sans: "Inter", sans-serif;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import "./assets/fonts/fonts.css";
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -39,6 +40,8 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
 }
 
 :root {


### PR DESCRIPTION
Add Inter font via Google Fonts and define global CSS variable

- Imported Inter font from Google Fonts in fonts.css
- Defined --font-sans in :root using Inter as the default sans-serif
- Ensures consistent global typography via CSS variables